### PR TITLE
Added new API state ids

### DIFF
--- a/src/chamberlain-accessory.js
+++ b/src/chamberlain-accessory.js
@@ -15,8 +15,10 @@ module.exports = class {
 
     this.apiToHap = {
       1: CurrentDoorState.OPEN,
+      9: CurrentDoorState.OPEN,
       2: CurrentDoorState.CLOSED,
       4: CurrentDoorState.OPENING,
+      0: CurrentDoorState.OPENING,
       5: CurrentDoorState.CLOSING
     };
 


### PR DESCRIPTION
It seems the API changed the ids of states. Kept the old ids intact just in case backwards compatibility is added later.