### PR TITLE
Patch for MyQ API Changes and Current Door State

### DIFF
--- a/src/chamberlain-accessory.js
+++ b/src/chamberlain-accessory.js
@@ -14,12 +14,16 @@ module.exports = class {
     const {CurrentDoorState, TargetDoorState} = Characteristic;
 
     this.apiToHap = {
+      // Legacy Values (leaving in case this is a defect with MyQ API)
       1: CurrentDoorState.OPEN,
-      9: CurrentDoorState.OPEN,
-      2: CurrentDoorState.CLOSED,
       4: CurrentDoorState.OPENING,
-      0: CurrentDoorState.OPENING,
-      5: CurrentDoorState.CLOSING
+      5: CurrentDoorState.CLOSING,
+      // This one is unchanged
+      2: CurrentDoorState.CLOSED,
+      // New state for OPEN
+      9: CurrentDoorState.OPEN,
+      // API no longer supports state of OPENING/CLOSING
+      0: -1
     };
 
     this.hapToApi = {
@@ -96,7 +100,18 @@ module.exports = class {
 
   getCurrentDoorState(cb) {
     return this.api.getDeviceAttribute({name: 'doorstate'})
-      .then(value => cb(null, this.apiToHap[value]))
+      .then(value =>{
+        let hapValue = this.apiToHap[value];
+        
+        // HACK for API changes
+        // If door is in a state of transition, make a best guess of opening/closing
+        if(hapValue === -1) {
+          // Check if target is to be open, if not assume close
+          hapValue = (this.targetDoorState === 1)? this.apiToHap[4] : this.apiToHap[5]
+        }
+
+        cb(null, hapValue);
+      })
       .catch(this.getErrorHandler(cb));
   }
 
@@ -104,9 +119,12 @@ module.exports = class {
     if (this.reactiveSetTargetDoorState) return cb();
 
     value = this.hapToApi[value];
+    this.targetDoorState = value;
+
     return this.api.setDeviceAttribute({name: 'desireddoorstate', value})
       .then(() => {
         this.poll();
+        this.targetDoorState = null;
         cb();
       })
       .catch(this.getErrorHandler(cb));

--- a/src/chamberlain-accessory.js
+++ b/src/chamberlain-accessory.js
@@ -15,8 +15,10 @@ module.exports = class {
 
     this.apiToHap = {
       1: CurrentDoorState.OPEN,
+      9: CurrentDoorState.OPEN,
       2: CurrentDoorState.CLOSED,
       4: CurrentDoorState.OPENING,
+      0: CurrentDoorState.OPENING,
       5: CurrentDoorState.CLOSING
     };
 


### PR DESCRIPTION
The MyQ API appears to have changed how it reports transition states of the garage door. Specifically, there is no longer a separation between `OPENING` and `CLOSING`, instead reporting back a status code of `0`. To remedy this, I left all the old codes in place (in the event that this is just a defect from MyQ), and added a translation of `0` to `-1`; from there we attempt to assume the transition state by checking the target door state.

As a note, I checked the MyQ iOS app, and it now reports `UNKNOWN` during transition states. If I had to guess, Chamberlain is probably making changes thanks to its new Homekit-compatible door opener.