### PR TITLE
Fix for devices not responding, or returning HTTP: 500 error

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -14,7 +14,7 @@ const req = ({body, headers, method, pathname, query}) =>
     body: body == null ? body : JSON.stringify(body),
     headers: _.extend({
       'Content-Type': 'application/json',
-      'User-Agent': 'Chamberlain/3.61.1 (iPhone; iOS 11.4.0; Scale/2.00)',
+      'User-Agent': 'N/A',
       ApiVersion: '4.1',
       BrandId: '2',
       Culture: 'en',


### PR DESCRIPTION
For those who want to do this locally,
On a Pi go to:
```/usr/lib/node-modules/homebridge-chamberlain/src```
Now you have to use sudo for the next part:
``` sudo nano api.js```
On line 17 Change
```'User-Agent': 'Chamberlain/3.61.1 (iPhone; iOS 11.4.0; Scale/2.00)',```  to ``` 'User-Agent': 'N/A',```

For those not on a Pi or Linux Distro, go to the Node-Modules folder and descend into homebridge-chamberlain/src then change line 17 and restart homebridge.

Edit:
This still uses the V4 Api, V5 api is the best for long term usage, but it's a fix for now and there's a PR open for the V5 Api if anyone wants to use it #56 