### PR TITLE
Proposed changes to address Fetcherror

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -15,10 +15,10 @@ const req = ({body, headers, method, pathname, query}) =>
     headers: _.extend({
       'Content-Type': 'application/json',
       'User-Agent': 'myQ/14041 CFNetwork/1107.1 Darwin/19.0.0',
-      ApiVersion: '4.1',
-      BrandId: '2',
-      Culture: 'en',
-      MyQApplicationId
+      'ApiVersion': '5.1',
+      'BrandId': '2',
+      'Culture': 'en',
+      'MyQApplicationId': MyQApplicationId
     }, headers),
     method
   }).then((res) => {
@@ -137,7 +137,7 @@ module.exports = class {
         ({SecurityToken, AccountId, MyQDeviceId}) =>
           req({
             method: 'GET',
-            pathname: '/api/v5/accounts/' + AccountId + '/devices/' + MyQDeviceId,
+            pathname: '/api/v5.1/Accounts/' + AccountId + '/Devices/' + MyQDeviceId,
             headers: {SecurityToken},
           }).then(({state}) => state[name])
       )


### PR DESCRIPTION
Compared api.js to other Homebridge plugins for MyQ in particular Homebridge-MyQ2 and found differences in the header formatting for requests to api.myqdevice.com. 

Making these changes in api.js appears to have addressed the Fetcherror issue independent of the IDLE_DELAY multiplier in chamberlain-accessory.js.