### PR TITLE
update node-fetch to version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "homebridge-plugin"
   ],
   "dependencies": {
-    "node-fetch": "1",
+    "node-fetch": "^2.0.0",
     "underscore": "1.8.3"
   },
   "engines": {


### PR DESCRIPTION
Updates node-fetch to version 2.

A review of the code indicates that none of the breaking changes in the library update require any modifications.