### PR TITLE
Update chamberlain-accessory.js

### DIFF
--- a/src/chamberlain-accessory.js
+++ b/src/chamberlain-accessory.js
@@ -3,7 +3,7 @@ const Api = require('./api');
 const instance = require('./instance');
 
 const ACTIVE_DELAY = 1000 * 2;
-const IDLE_DELAY = 1000 * 10;
+const IDLE_DELAY = 1000 * 30;
 
 module.exports = class {
   constructor(log, {deviceId, name, password, username}) {
@@ -78,7 +78,7 @@ module.exports = class {
 
     if (name === 'doorstate') {
       this.reactiveSetTargetDoorState = true;
-      this.states.desireddoorstate.setValue(this.currentToTarget[newValue]);
+      this.states.desireddoorstate.updateValue(this.currentToTarget[newValue]);
       delete this.reactiveSetTargetDoorState;
     }
   }


### PR DESCRIPTION
Updates include:
- change IDLE_DELAY multiplier from *10 to *30 to reduce myQ server polling and as a result reduce probability of ECONNRESET errors. My experience has been that the *30 multiplier reduces the error from several times per day to less than once per day on average.
- use "updateValue" rather than "setValue" as advised by @kbardai (https://github.com/iRayanKhan/homebridge-chamberlain/issues/75#issuecomment-600262488). Confirmed that garage door operation not impacted with this change.