### PR TITLE
Additional changes for ECONNRESET issue

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -15,7 +15,7 @@ const req = ({body, headers, method, pathname, query}) =>
     headers: _.extend({
       'Content-Type': 'application/json',
       'User-Agent': 'myQ/14041 CFNetwork/1107.1 Darwin/19.0.0',
-      ApiVersion: '4.1',
+      ApiVersion: '5.1',
       BrandId: '2',
       Culture: 'en',
       MyQApplicationId
@@ -80,7 +80,7 @@ module.exports = class {
       this.getAccountId(options).then(AccountId =>
         req({
           method: 'GET',
-          pathname: '/api/v5/Accounts/' + AccountId + '/Devices',
+          pathname: '/api/v5.1/Accounts/' + AccountId + '/Devices',
           headers: {SecurityToken},
           query: {filterOn: 'true'}
         })
@@ -137,7 +137,7 @@ module.exports = class {
         ({SecurityToken, AccountId, MyQDeviceId}) =>
           req({
             method: 'GET',
-            pathname: '/api/v5/accounts/' + AccountId + '/devices/' + MyQDeviceId,
+            pathname: '/api/v5.1/Accounts/' + AccountId + '/devices/' + MyQDeviceId,
             headers: {SecurityToken},
           }).then(({state}) => state[name])
       )


### PR DESCRIPTION
Since submitting previous updates I started receiving additional but different ECONNRESET errors. Tracing back to the api.js code I changed "/api/v5/Accounts" to "/api/v5.1/Accounts" in 2 places as well as in the headers: section. 

Additionally updated npm to @latest (v6.14.3). Have not observed any ECONNRESET errors in the last 2 days from any of my plugins which may indicate that the change to npm provides a general fix for the problem. Reviewed the nom release notes and not obvious that there were specific changes that would address this issue as a general fix.